### PR TITLE
Fix: user data is not showing up in memberSkillsUpdateModal

### DIFF
--- a/src/components/NewMemberSection/NewMemberCard/index.tsx
+++ b/src/components/NewMemberSection/NewMemberCard/index.tsx
@@ -1,10 +1,13 @@
-import { useState } from 'react';
-import NewMemberCardPresentation from './Presentation';
-import { useDispatch, useSelector } from 'react-redux';
-import { setIsUserRoleUpdateModalVisible, setUserSkillModalVisibility } from '@/src/store/superUserOptions';
-import { RootState } from '@/src/store';
-import { useGetIsSuperUser } from '@/src/utils/customHooks';
-import { useRouter } from 'next/router';
+import { useState } from "react";
+import NewMemberCardPresentation from "./Presentation";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  setIsUserRoleUpdateModalVisible,
+  setUserSkillModalVisibility,
+} from "@/src/store/superUserOptions";
+import { RootState } from "@/src/store";
+import { useGetIsSuperUser } from "@/src/utils/customHooks";
+import { useRouter } from "next/router";
 
 export default function NewMemberCard({ user }: { user: MemberType }) {
   const [shouldShowSetting, setShouldShowSetting] = useState(false);
@@ -38,7 +41,15 @@ export default function NewMemberCard({ user }: { user: MemberType }) {
 
   function openSkillUpdateModal() {
     hideSetting();
-    reduxDispatch(setUserSkillModalVisibility({ visibility: true, userId: user.username }));
+    reduxDispatch(
+      setUserSkillModalVisibility({
+        visibility: true,
+        userId: user.username,
+        picture: user?.picture?.url,
+        firstName: user?.first_name,
+        lastName: user?.last_name,
+      })
+    );
   }
 
   function onCardClick() {


### PR DESCRIPTION
**Closes:** https://github.com/Real-Dev-Squad/members-site/issues/92

**What is change?**
- Added firstName, lastName and profile picture of user in `superUserOptions` so when `super_user` try to update the skills of particular user then in modal we are showing their firstName, lastName and profile picture.

Issue: https://github.com/Real-Dev-Squad/members-site/issues/94


Before:-
![Real Dev Squad - Google Chrome 06-09-2023 17_47_05](https://github.com/Real-Dev-Squad/members-site/assets/22213872/d213fa58-d44f-4fe4-a84c-9311f5e4e1d6)


After:-
![New Tab - Google Chrome 07-09-2023 02_35_32](https://github.com/Real-Dev-Squad/members-site/assets/22213872/5b29b868-1c67-484e-b583-b4e8cf71d144)
