### PR TITLE
replace /members with /users API

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import { NEW_USER, NUM_MEMBERS_NUMBER } from "@/src/constants/AppConstants";
 import styles from "@/styles/Home.module.css";
 import MembersSectionMain from "@/src/components/MembersSectionNew/MembersSectionMain";
 import NewMemberSection from "@/src/components/NewMemberSection";
-
+import { UserType } from "../src/components/MembersSectionNew/types/MembersSection.type";
 type PictureType = {
   publicId: string;
   url: string;
@@ -16,27 +16,6 @@ type PictureType = {
 type RolesType = {
   archived: boolean;
   member: boolean;
-};
-
-type UserType = {
-  id: string;
-  yoe: number;
-  picture: PictureType;
-  github_id: string;
-  linkedin_id: string;
-  instagram_id: string;
-  twitter_id: string;
-  roles: RolesType;
-  last_name: string;
-  profileURL: string;
-  designation: string;
-  github_display_name: null;
-  company: string;
-  username: string;
-  first_name: string;
-  profileStatus: string;
-  status: string;
-  incompleteUserDetails: boolean;
 };
 
 type MembersResponseType = {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Image from "next/image";
 import { wrapper } from "@/src/store";
-import serverApi, { useGetMembersQuery } from "../src/services/serverApi";
+import serverApi, { useGetAllUsersQuery } from "../src/services/serverApi";
 // import NewMembersCard from "@/src/components/NewMember";
 import { NEW_USER, NUM_MEMBERS_NUMBER } from "@/src/constants/AppConstants";
 import styles from "@/styles/Home.module.css";
@@ -18,7 +18,7 @@ type RolesType = {
   member: boolean;
 };
 
-type MemberType = {
+type UserType = {
   id: string;
   yoe: number;
   picture: PictureType;
@@ -41,7 +41,7 @@ type MemberType = {
 
 type MembersResponseType = {
   message: string;
-  members: MemberType[];
+  members: UserType[];
 };
 
 type PagePropsType = {

--- a/src/components/MembersSectionNew/components/MembersCard/Presentation.tsx
+++ b/src/components/MembersSectionNew/components/MembersCard/Presentation.tsx
@@ -2,7 +2,7 @@ import { Box, Text, Flex, Image } from "@chakra-ui/react";
 
 import Socials from "../Socials";
 
-import { MemberType } from "../../types/MembersSection.type";
+import { UserType } from "../../types/MembersSection.type";
 
 import styles from "./membersCard.module.css";
 import SettingButton from "../../../SettingButton/SettingButton";
@@ -18,7 +18,7 @@ export default function MembersCardPresentation({
   routeHandler,
   isSuperUser,
 }: {
-  member: MemberType;
+  member: UserType;
   openSkillUpdateModal: (e: SyntheticEvent) => void;
   openRoleUpdateModal: (e: SyntheticEvent) => void;
   shouldShowSetting: boolean;

--- a/src/components/MembersSectionNew/components/MembersCard/index.tsx
+++ b/src/components/MembersSectionNew/components/MembersCard/index.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { useDispatch, useSelector } from "react-redux";
-import { MemberType } from "../../types/MembersSection.type";
+import { UserType } from "../../types/MembersSection.type";
 import MembersCardPresentation from "./Presentation";
 import {
   setIsUserRoleUpdateModalVisible,
@@ -10,7 +10,7 @@ import { RootState } from "@/src/store";
 import { SyntheticEvent, useState } from "react";
 import { useGetIsSuperUser } from "@/src/utils/customHooks";
 
-export default function MembersCard({ member }: { member: MemberType }) {
+export default function MembersCard({ member }: { member: UserType }) {
   const [shouldShowSetting, setShouldShowSetting] = useState(false);
   const isSuperUser = useGetIsSuperUser()
   const reduxDispatch = useDispatch();

--- a/src/components/MembersSectionNew/types/MembersSection.type.tsx
+++ b/src/components/MembersSectionNew/types/MembersSection.type.tsx
@@ -1,5 +1,5 @@
 export type MemberProps = {
-  data: MemberType[] | undefined,
+  data: UserType[] | undefined,
   isLoading: boolean
 };
 
@@ -15,7 +15,7 @@ type RolesType = {
   in_discord?:boolean
 };
 
-export type MemberType = {
+export type UserType = {
   id: string;
   yoe: number;
   picture: PictureType;
@@ -36,5 +36,4 @@ export type MemberType = {
   incompleteUserDetails: boolean;
   discordId: string;
   chaincode: string;
-  isMember: boolean;
 };

--- a/src/components/Modals/MembersSkillUpdateModal/components/MembersActiveSkills/Skills.tsx
+++ b/src/components/Modals/MembersSkillUpdateModal/components/MembersActiveSkills/Skills.tsx
@@ -6,7 +6,7 @@ import { useRemoveSkillsMutation } from "../../../../../services/serverApi";
 import { skills } from "../../types/memberSkills";
 
 import styles from "./membersActiveSkills.module.css";
-import { notifyError, notifySuccess } from "@/src/utils/toast";
+import { notifyError, notifySuccess } from "../../../../../utils/toast";
 
 export default function Skills({
   username,

--- a/src/components/NewMemberSection/NewMemberCard/index.tsx
+++ b/src/components/NewMemberSection/NewMemberCard/index.tsx
@@ -9,7 +9,7 @@ import { RootState } from "@/src/store";
 import { useGetIsSuperUser } from "@/src/utils/customHooks";
 import { useRouter } from "next/router";
 
-export default function NewMemberCard({ user }: { user: MemberType }) {
+export default function NewMemberCard({ user }: { user: UserType }) {
   const [shouldShowSetting, setShouldShowSetting] = useState(false);
   const isSuperUser = useGetIsSuperUser();
   const router = useRouter();

--- a/src/mocks/db/allUsers.ts
+++ b/src/mocks/db/allUsers.ts
@@ -1,4 +1,4 @@
-export const membersData = [
+export const usersData = [
   {
     id: "2LYhIJRQBPypkcCuuW7q",
     incompleteUserDetails: true,
@@ -11,7 +11,6 @@ export const membersData = [
       super_user: false,
     },
     github_id: "manish591",
-    isMember: false,
   },
   {
     id: "3XDExvejTrg6YbeSPKtr",
@@ -26,7 +25,6 @@ export const membersData = [
     github_id: "vinayak-trivedi",
     first_name: "vinayak",
     username: "vinayak",
-    isMember: false,
   },
   {
     id: "3kcyMhE0PyEjLrxKjLcu",
@@ -40,7 +38,6 @@ export const membersData = [
       member: false,
     },
     github_id: "pallabez",
-    isMember: false,
   },
   {
     company: "Christ Church college",
@@ -53,7 +50,6 @@ export const membersData = [
     id: "A27aga8IGIfVO1NAtH2G",
     incompleteUserDetails: false,
     instagram_id: "",
-    isMember: true,
     last_name: "Trivedi",
     linkedin_id: "vinayak-trivedi-9b6212218",
     picture: {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,7 +2,7 @@ import tagsHandler from "./handlers/tags.handler";
 import skillsHandler from "./handlers/skills.handler";
 import levelsHandler from "./handlers/levels.handler";
 import { itemsHandler } from "./handlers/items.handler";
-import membersHandler from "./handlers/member.handler";
+import allUsersHandler from "./handlers/allUsers.handler";
 import userHandler from "./handlers/user.handler";
 import selfUserHandler from "./handlers/self.handler";
 import contributionsHandler from "./handlers/contributions.handler";
@@ -14,7 +14,7 @@ export const handlers = [
   ...levelsHandler,
   ...skillsHandler,
   ...itemsHandler,
-  ...membersHandler,
+  ...allUsersHandler,
   ...userHandler,
   ...selfUserHandler,
   ...contributionsHandler,

--- a/src/mocks/handlers/allUsers.handler.ts
+++ b/src/mocks/handlers/allUsers.handler.ts
@@ -1,16 +1,16 @@
 import { rest } from "msw";
-import { membersData } from "../db/members";
+import { usersData } from "../db/allUsers";
 const URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 const username = 'vinayak';
 
-const membersHandler = [
-    rest.get(`${URL}/members`, (_, res, ctx) => {
+const allUsersHandler = [
+    rest.get(`${URL}/users`, (_, res, ctx) => {
         return res(
             ctx.status(200),
             ctx.json({
-                message: 'Members returned successfully!',
-                members: membersData
+                message: 'Users returned successfully!',
+                users: usersData
             })
         )
     }),
@@ -26,4 +26,4 @@ const membersHandler = [
     })
 ];
 
-export default membersHandler;
+export default allUsersHandler;

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { HYDRATE } from 'next-redux-wrapper';
 import { tags, levels, tagsWithLevelType, skills, updateSkills } from '../components/Modals/MembersSkillUpdateModal/types/memberSkills';
 import { UserType } from '../components/MembersSectionNew/types/MembersSection.type';
+import { UsersResponseType } from '../types/user';
 import { useDispatch } from 'react-redux';
 import { notifyError, notifySuccess } from '../utils/toast';
 const BASE_URL = 'https://api.realdevsquad.com';
@@ -204,7 +205,8 @@ export const filteredTagsData = (
     return tags?.filter((tag) =>
       tag.name.toLowerCase().includes(searchSkill.toLowerCase())
     );
-  } else if (skills?.length >= 0) {
+  }
+  if (skills?.length >= 0) {
     return tags?.filter(
       (tag) =>
         !skills?.some(

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -18,7 +18,7 @@ export const serverApi = createApi({
   endpoints: (builder) => ({
     // Queries
     getAllUsers: builder.query<UsersResponseType, void>({
-      query: () => BASE_URL + '/users',
+      query: () => BASE_URL + '/users?size=100',
       providesTags: ['AllUsers']
     }),
     getUser: builder.query<UserType, string>({

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -103,11 +103,11 @@ export const useGetMembers = () => {
 export const useGetUsers = () => {
   const { data, isLoading, isFetching, error } = serverApi.useGetAllUsersQuery()
   const usersWithoutMemberRole = data?.users?.filter(
-    (nonMember: UserType) =>
-      !nonMember?.roles.member &&
-      nonMember?.first_name &&
-      !nonMember.roles.archived &&
-      nonMember.roles.in_discord
+    (user: UserType) =>
+      !user?.roles.member &&
+      user?.first_name &&
+      !user.roles.archived &&
+      user.roles.in_discord
   );
   // To show the Non-members in an Alphabetical Order w.r.t their first name
   const sortedNonMembers = usersWithoutMemberRole?.sort((a, b) => a.first_name > b.first_name ? 1 : -1)

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -90,7 +90,7 @@ export const useGetMembers = () => {
     (member: UserType) =>
       member?.roles.member === true && member?.first_name && !member.roles.archived
   );
-
+  // To show the members in an Alphabetical Order w.r.t their first name.
   const sortedMembers = usersWithMemberRole?.sort((a, b) => a.first_name > b.first_name ? 1 : -1)
   return {
     data: sortedMembers,
@@ -109,6 +109,7 @@ export const useGetUsers = () => {
       !nonMember.roles.archived &&
       nonMember.roles.in_discord
   );
+  // To show the Non-members in an Alphabetical Order w.r.t their first name
   const sortedNonMembers = usersWithoutMemberRole?.sort((a, b) => a.first_name > b.first_name ? 1 : -1)
 
   return {

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { HYDRATE } from 'next-redux-wrapper';
 import { tags, levels, tagsWithLevelType, skills, updateSkills } from '../components/Modals/MembersSkillUpdateModal/types/memberSkills';
-import { MemberType } from '../components/MembersSectionNew/types/MembersSection.type';
+import { UserType } from '../components/MembersSectionNew/types/MembersSection.type';
 import { useDispatch } from 'react-redux';
 import { notifyError, notifySuccess } from '../utils/toast';
 const BASE_URL = 'https://api.realdevsquad.com';
@@ -13,18 +13,18 @@ export const serverApi = createApi({
       return action.payload[reducerPath];
     }
   },
-  tagTypes: ['Skill', 'Contributions', 'ActiveTasks', 'Members', 'User'],
+  tagTypes: ['Skill', 'Contributions', 'ActiveTasks', 'AllUsers', 'User'],
   endpoints: (builder) => ({
     // Queries
-    getMembers: builder.query<MembersResponseType, void>({
-      query: () => BASE_URL + '/members',
-      providesTags: ['Members']
+    getAllUsers: builder.query<UsersResponseType, void>({
+      query: () => BASE_URL + '/users',
+      providesTags: ['AllUsers']
     }),
-    getUser: builder.query<MemberType, string>({
+    getUser: builder.query<UserType, string>({
       query: (userName) => `${BASE_URL}/users/${userName}`,
       providesTags: ['User']
     }),
-    getSelfDetails: builder.query<MemberType, void>({
+    getSelfDetails: builder.query<UserType, void>({
       query: () => `${BASE_URL}/users/self`,
     }),
     getContributions: builder.query<Object, string>({
@@ -55,7 +55,7 @@ export const serverApi = createApi({
         method: 'PATCH',
         body
       }),
-      invalidatesTags: ['Members', 'User']
+      invalidatesTags: ['AllUsers', 'User']
     }),
     updateTaskStatus: builder.mutation({
       query: ({ isNoteworthy, taskId }) => ({
@@ -73,7 +73,7 @@ export const serverApi = createApi({
 export const {
   useArchiveMemberMutation,
   useGetContributionsQuery,
-  useGetMembersQuery,
+  useGetAllUsersQuery,
   useGetUserActiveTaskQuery,
   useGetUserQuery,
   useGetSelfDetailsQuery,
@@ -83,15 +83,16 @@ export const {
 } = serverApi;
 
 export const useGetMembers = () => {
-  const { data, isLoading, isFetching, error } = serverApi.useGetMembersQuery()
-  const membersWithRole = data?.members?.filter(
-    (member: MemberType) =>
-      member?.isMember === true && member?.first_name && !member.roles.archived
-  );
-  const sortedUsers = membersWithRole?.sort((a,b) => a.first_name > b.first_name ? 1 : -1) 
+  const { data, isLoading, isFetching, error } = serverApi.useGetAllUsersQuery();
 
+  const usersWithMemberRole = data?.users?.filter(
+    (member: UserType) =>
+      member?.roles.member === true && member?.first_name && !member.roles.archived
+  );
+
+  const sortedMembers = usersWithMemberRole?.sort((a, b) => a.first_name > b.first_name ? 1 : -1)
   return {
-    data: sortedUsers,
+    data: sortedMembers,
     isLoading,
     isFetching,
     error
@@ -99,18 +100,18 @@ export const useGetMembers = () => {
 }
 
 export const useGetUsers = () => {
-  const { data, isLoading, isFetching, error } = serverApi.useGetMembersQuery()
-  const membersWithRole = data?.members?.filter(
-    (member: MemberType) =>
-      member?.isMember === false &&
-      member?.first_name &&
-      !member.roles.archived &&
-      member.roles.in_discord
+  const { data, isLoading, isFetching, error } = serverApi.useGetAllUsersQuery()
+  const usersWithoutMemberRole = data?.users?.filter(
+    (nonMember: UserType) =>
+      !nonMember?.roles.member &&
+      nonMember?.first_name &&
+      !nonMember.roles.archived &&
+      nonMember.roles.in_discord
   );
-  const sortedUsers = membersWithRole?.sort((a,b) => a.first_name > b.first_name ? 1 : -1) 
+  const sortedNonMembers = usersWithoutMemberRole?.sort((a, b) => a.first_name > b.first_name ? 1 : -1)
 
   return {
-    data: sortedUsers,
+    data: sortedNonMembers,
     isLoading,
     isFetching,
     error
@@ -195,47 +196,47 @@ export const useGetLevels = () => {
 };
 
 export const filteredTagsData = (
-    tags: tagsWithLevelType[],
-    skills: skills[],
-    searchSkill: string
-  ) => {
-    if (searchSkill !== "") {
-      return tags?.filter((tag) =>
-        tag.name.toLowerCase().includes(searchSkill.toLowerCase())
-      );
-    } else if (skills?.length >= 0) {
-      return tags?.filter(
-        (tag) =>
-          !skills?.some(
-            (skill) =>
-              skill.tagId === tag.tagId && skill.levelId === tag.levelId
-          )
-      );
-    }
-    return tags;
-  };
+  tags: tagsWithLevelType[],
+  skills: skills[],
+  searchSkill: string
+) => {
+  if (searchSkill !== "") {
+    return tags?.filter((tag) =>
+      tag.name.toLowerCase().includes(searchSkill.toLowerCase())
+    );
+  } else if (skills?.length >= 0) {
+    return tags?.filter(
+      (tag) =>
+        !skills?.some(
+          (skill) =>
+            skill.tagId === tag.tagId && skill.levelId === tag.levelId
+        )
+    );
+  }
+  return tags;
+};
 
-  export const useUpdateUsersSKillMutation = () => {
-    const reduxDispatch = useDispatch<any>();
-    const [ addNewSkill ] = useAddNewSkillMutation();
+export const useUpdateUsersSKillMutation = () => {
+  const reduxDispatch = useDispatch<any>();
+  const [addNewSkill] = useAddNewSkillMutation();
 
-    function updateUserSkill(payload: updateSkills) {
-      reduxDispatch(
-        tagsApi.util.updateQueryData('getSkills', payload.itemId, (draft) => {
-          draft?.skills?.push(payload);
-        })
-      )
-
-      addNewSkill({
-        itemId: payload.itemId,
-        itemType: 'USER',
-        tagPayload: [
-          {
-            tagId: payload.tagId,
-            levelId: payload.levelId
-          }
-        ]
+  function updateUserSkill(payload: updateSkills) {
+    reduxDispatch(
+      tagsApi.util.updateQueryData('getSkills', payload.itemId, (draft) => {
+        draft?.skills?.push(payload);
       })
+    )
+
+    addNewSkill({
+      itemId: payload.itemId,
+      itemType: 'USER',
+      tagPayload: [
+        {
+          tagId: payload.tagId,
+          levelId: payload.levelId
+        }
+      ]
+    })
       .unwrap()
       .then(() => {
         notifySuccess('Skill added successfully')
@@ -244,9 +245,9 @@ export const filteredTagsData = (
         const errorMessage = error?.data?.message || 'Something went wrong!';
         notifyError(errorMessage);
       })
-    }
-
-    return [ updateUserSkill ];
   }
+
+  return [updateUserSkill];
+}
 
 export default serverApi;

--- a/src/test/functions/useGetMembers.test.tsx
+++ b/src/test/functions/useGetMembers.test.tsx
@@ -1,4 +1,4 @@
-import { useGetMembers, useGetMembersQuery } from "../../services/serverApi";
+import { useGetMembers, useGetAllUsersQuery } from "../../services/serverApi";
 import { Provider } from "react-redux";
 import { store } from "../../store/index";
 
@@ -28,7 +28,7 @@ describe("useGetMembers", () => {
     });
 
     const { result: membersResult, waitForNextUpdate } = renderHook(
-      () => useGetMembersQuery(),
+      () => useGetAllUsersQuery(),
       {
         wrapper: Wrapper,
       }

--- a/src/test/functions/useGetUsers.test.tsx
+++ b/src/test/functions/useGetUsers.test.tsx
@@ -1,4 +1,4 @@
-import { useGetUsers, useGetMembersQuery } from "../../services/serverApi";
+import { useGetUsers, useGetAllUsersQuery } from "../../services/serverApi";
 import { Provider } from "react-redux";
 import { store } from "../../store/index";
 
@@ -22,13 +22,13 @@ function Wrapper({
 }
 
 describe("useGetUsers", () => {
-  test("it should returns members", async () => {
+  test("it should return all users", async () => {
     const { result } = renderHook(() => useGetUsers(), {
       wrapper: Wrapper,
     });
 
     const { result: membesResult, waitForNextUpdate } = renderHook(
-      () => useGetMembersQuery(),
+      () => useGetAllUsersQuery(),
       {
         wrapper: Wrapper,
       }

--- a/src/test/hooks/membersApi.test.tsx
+++ b/src/test/hooks/membersApi.test.tsx
@@ -1,5 +1,5 @@
 import {
-  useGetMembersQuery,
+  useGetAllUsersQuery,
   useUpdateMemberRoleMutation,
   useArchiveMemberMutation,
 } from "../../services/serverApi";
@@ -25,10 +25,10 @@ function Wrapper({
   return <Provider store={store}>{children}</Provider>;
 }
 
-describe("it shoud test all the members RTK query hooks", () => {
-  test("returns members", async () => {
+describe("it shoud test all the users RTK query hooks", () => {
+  test("it should return all users", async () => {
     const { result, waitForNextUpdate } = renderHook(
-      () => useGetMembersQuery(),
+      () => useGetAllUsersQuery(),
       { wrapper: Wrapper }
     );
 
@@ -40,8 +40,8 @@ describe("it shoud test all the members RTK query hooks", () => {
 
     const nextResponse = result.current;
     expect(nextResponse?.data).not.toBeUndefined();
-    expect(nextResponse?.data?.message).toBe("Members returned successfully!");
-    expect(nextResponse?.data?.members).toHaveLength(3);
+    expect(nextResponse?.data?.message).toBe("Users returned successfully!");
+    expect(nextResponse?.data?.users).toHaveLength(4);
   });
 
   test("it should promote user to member", async () => {
@@ -73,7 +73,7 @@ describe("it shoud test all the members RTK query hooks", () => {
     expect(loadedResponse.isSuccess).toBe(true);
   });
 
-  test("it should archive member", async () => {
+  test("it should archive user", async () => {
     const { result, waitForNextUpdate } = renderHook(
       () => useArchiveMemberMutation(),
       {

--- a/src/test/unit/components/member-card/MembersCardPresentation.test.tsx
+++ b/src/test/unit/components/member-card/MembersCardPresentation.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../test__utils/renderWithProvides";
-import { membersData } from "../../../../mocks/db/members";
+import { usersData } from "../../../../mocks/db/allUsers";
 
 import MembersCardPresentation from "../../../../components/MembersSectionNew/components/MembersCard/Presentation";
 import SettingButton from "../../../../components/SettingButton/SettingButton";
@@ -15,7 +15,7 @@ describe("MembersCardPresentation", () => {
 
     renderWithProviders(
       <MembersCardPresentation
-        member={membersData[3]}
+        member={usersData[3]}
         openRoleUpdateModal={openUserRoleUpdateModal}
         openSkillUpdateModal={openSkillUpdateModal}
         shouldShowSetting={false}
@@ -27,7 +27,7 @@ describe("MembersCardPresentation", () => {
     );
 
     const userImage = screen.getAllByAltText("Picture of the author");
-    expect(userImage).toHaveLength(2);
+    expect(userImage).toHaveLength(1);
 
     const username = screen.getByRole("heading", {
       name: /vinayak trivedi/i,
@@ -49,7 +49,7 @@ describe("MembersCardPresentation", () => {
 
     renderWithProviders(
       <MembersCardPresentation
-        member={membersData[3]}
+        member={usersData[3]}
         openRoleUpdateModal={openUserRoleUpdateModal}
         openSkillUpdateModal={openSkillUpdateModal}
         shouldShowSetting={true}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,3 +1,5 @@
+import { UserType } from "../../src/components/MembersSectionNew/types/MembersSection.type";
+
 type PictureType = {
   publicId: string;
   url: string;
@@ -6,29 +8,6 @@ type PictureType = {
 type RolesType = {
   archived: boolean;
   member: boolean;
-};
-
-type UserType = {
-  id: string;
-  yoe: number;
-  picture: PictureType;
-  github_id: string;
-  linkedin_id: string;
-  instagram_id: string;
-  twitter_id: string;
-  roles: RolesType;
-  last_name: string;
-  profileURL: string;
-  designation: string;
-  github_display_name: null;
-  company: string;
-  username: string;
-  first_name: string;
-  profileStatus: string;
-  status: string;
-  incompleteUserDetails: boolean;
-  discordId: string;
-  chaincode: string;
 };
 
 type UsersResponseType = {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,7 +10,7 @@ type RolesType = {
   member: boolean;
 };
 
-type UsersResponseType = {
+export type UsersResponseType = {
   message: string;
   users: UserType[];
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,7 +8,7 @@ type RolesType = {
   member: boolean;
 };
 
-type MemberType = {
+type UserType = {
   id: string;
   yoe: number;
   picture: PictureType;
@@ -29,10 +29,9 @@ type MemberType = {
   incompleteUserDetails: boolean;
   discordId: string;
   chaincode: string;
-  isMember: boolean;
 };
 
-type MembersResponseType = {
+type UsersResponseType = {
   message: string;
-  members: MemberType[];
+  users: UserType[];
 };


### PR DESCRIPTION
### Issue:
- [ ] https://github.com/Real-Dev-Squad/website-members/issues/547


### Description:
As a part of deprecating the routes of `/members` with `/users`  the route `/members` in the main page needs to be replaced with `/users` which returns all the users.

### Design Doc:
https://docs.google.com/document/d/1xvllP-qyZBAHFzp5Oh-7d-bTh_JHX7Ps_KsOTUSkPYE/edit?usp=sharing

### Changes:

- Replaced **membersHandler** which uses `/members`, with **allUsersHandler** which uses `/users`.
- **useGetMembersQuery()** has been replaced with **useGetAllUsersQuery()**.
- Updated variable naming with respect to the /users API. 
- Updated  users API response as mock data used in the test files.
- Updated test-files with respect to the response from the `/users` API.

### Anything you would like to inform the reviewer about:
This PR is one of the multiple other PR's which are addressing the above mentioned issue.

### Dev Tested:
- [x] Yes

### Images/video of the change:
**Before:**
![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/dedfcd5f-aec5-4c83-a53a-2cb8ea199f6d)


**After:**
![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/eab56d13-26dd-411d-a5be-c1ad45a96d76)

### Test Coverage Stats:
![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/18a2b6ed-38f3-4587-9640-d25ea5a13266)

![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/8f27c384-3443-4630-9067-c22a13e100ac)

![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/11e4f17f-f502-47ac-87ae-a0e9f6adadc7)

![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/073e7bdc-0abf-4589-9e83-0fbd42da4b8d)

![image](https://github.com/Real-Dev-Squad/members-site/assets/69259490/21d730b0-8e91-4546-9619-ef617a23b825)



### Follow-up Issues (if any):
None