### PR TITLE
Setup global state for user self data

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,35 +1,46 @@
 import { Dispatch, SetStateAction } from "react";
 import { useDispatch } from "react-redux";
-import { setIsLoggedIn } from "@/src/store/global";
-
-import { notifyError, notifySuccess } from '../../utils/toast';
-import { DropdownPresentation } from "./Presentation";
+import { setIsLoggedIn, setUserData } from "@/src/store/global";
+import { useLogoutUserMutation } from "@/src/services/logoutApi";
 
 import { DROPDOWN_LINKS } from "./DropdownConstants";
 
-import styles from "./dropdown.module.css";
-import { useLogoutUserMutation } from "@/src/services/logoutApi";
+import { notifyError, notifySuccess } from "../../utils/toast";
+import { DropdownPresentation } from "./Presentation";
 
-export default function Dropdown({ setIsDropdownVisible } : {
-    setIsDropdownVisible: Dispatch<SetStateAction<boolean>>;
+export default function Dropdown({
+  setIsDropdownVisible,
+}: {
+  setIsDropdownVisible: Dispatch<SetStateAction<boolean>>;
 }) {
-    const reduxDispatch = useDispatch();
-    const [ logoutUser ] = useLogoutUserMutation();
+  const reduxDispatch = useDispatch();
+  const [logoutUser] = useLogoutUserMutation();
 
-    const logout = () => {
-        logoutUser()
-          .unwrap()
-          .then(() => {
-            reduxDispatch(setIsLoggedIn({isLoggedIn: false}));
-            notifySuccess('User logged out successfully')
+  const logout = () => {
+    logoutUser()
+      .unwrap()
+      .then(() => {
+        reduxDispatch(setIsLoggedIn({ isLoggedIn: false }));
+        reduxDispatch(
+          setUserData({
+            first_name: null,
+            imageURL: null,
+            roles: null,
           })
-          .catch((error) => {
-            const errorMessage = error?.data?.message || 'Something went wrong!';
-            notifyError(errorMessage);
-          })
-    }
+        );
+        notifySuccess("User logged out successfully");
+      })
+      .catch((error) => {
+        const errorMessage = error?.data?.message || "Something went wrong!";
+        notifyError(errorMessage);
+      });
+  };
 
-    return (
-      <DropdownPresentation logout={logout} dropdownLinks={DROPDOWN_LINKS} setIsDropdownVisible={setIsDropdownVisible} />
-    )
+  return (
+    <DropdownPresentation
+      logout={logout}
+      dropdownLinks={DROPDOWN_LINKS}
+      setIsDropdownVisible={setIsDropdownVisible}
+    />
+  );
 }

--- a/src/components/Layout/Navbar/components/UserProfile.tsx
+++ b/src/components/Layout/Navbar/components/UserProfile.tsx
@@ -1,34 +1,40 @@
-import { useGetSelfDetailsQuery } from "../../../../services/serverApi";
 import { Box, Text } from "@chakra-ui/react";
 import Image from "next/image";
+import { useSelector } from "react-redux";
+import { RootState } from "@/src/store";
 
 import { Dispatch, SetStateAction } from "react";
 
 import styles from "./userProfile.module.css";
 
-export default function UserProfile({ isDropdownVisible, setIsDropdownVisible} : {
+export default function UserProfile({
+  isDropdownVisible,
+  setIsDropdownVisible,
+}: {
   isDropdownVisible: boolean;
   setIsDropdownVisible: Dispatch<SetStateAction<boolean>>;
 }) {
-  const { data: user, isLoading } = useGetSelfDetailsQuery();
-  const imageToShow = user?.picture?.url || '/images/Avatar.png';
+  const { first_name, imageURL } = useSelector(
+    (state: RootState) => state.global
+  );
 
-  if (isLoading) return <></>;
+  const imageToShow = imageURL || "/images/Avatar.png";
+
   return (
-      <Box
-        className={styles.userprofile_container}
-        onClick={() => setIsDropdownVisible(!isDropdownVisible)}
-      >
-        <Text
-          className={styles.userprofile_user__first_name}
-        >{`Hello, ${user?.first_name}`}</Text>
-        <Image
-          src={imageToShow}
-          style={{ borderRadius: '50%' }}
-          width={32}
-          height={32}
-          alt=''
-        />
-      </Box>
+    <Box
+      className={styles.userprofile_container}
+      onClick={() => setIsDropdownVisible(!isDropdownVisible)}
+    >
+      <Text
+        className={styles.userprofile_user__first_name}
+      >{`Hello, ${first_name}`}</Text>
+      <Image
+        src={imageToShow}
+        style={{ borderRadius: "50%" }}
+        width={32}
+        height={32}
+        alt=""
+      />
+    </Box>
   );
 }

--- a/src/components/MembersSectionNew/types/MembersSection.type.tsx
+++ b/src/components/MembersSectionNew/types/MembersSection.type.tsx
@@ -1,6 +1,6 @@
 export type MemberProps = {
-  data: UserType[] | undefined,
-  isLoading: boolean
+  data: UserType[] | undefined;
+  isLoading: boolean;
 };
 
 type PictureType = {
@@ -8,11 +8,11 @@ type PictureType = {
   url: string;
 };
 
-type RolesType = {
+export type RolesType = {
   archived: boolean;
   member: boolean;
-  super_user?: boolean
-  in_discord?:boolean
+  super_user?: boolean;
+  in_discord?: boolean;
 };
 
 export type UserType = {

--- a/src/components/NewMemberSection/NewMemberCard/index.tsx
+++ b/src/components/NewMemberSection/NewMemberCard/index.tsx
@@ -8,6 +8,7 @@ import {
 import { RootState } from "@/src/store";
 import { useGetIsSuperUser } from "@/src/utils/customHooks";
 import { useRouter } from "next/router";
+import { UserType } from "../../MembersSectionNew/types/MembersSection.type";
 
 export default function NewMemberCard({ user }: { user: UserType }) {
   const [shouldShowSetting, setShouldShowSetting] = useState(false);

--- a/src/components/UtilComponents/AuthHandler.tsx
+++ b/src/components/UtilComponents/AuthHandler.tsx
@@ -1,5 +1,5 @@
 import { useGetSelfDetailsQuery } from "@/src/services/serverApi";
-import { setIsLoggedIn } from "@/src/store/global";
+import { setIsLoggedIn, setUserData } from "@/src/store/global";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
@@ -7,14 +7,22 @@ type Props = {
   children: JSX.Element;
 };
 
-
 export default function AuthHandler(props: Props) {
-  const {data: user, isLoading} = useGetSelfDetailsQuery()
-  const reduxDispatch = useDispatch()
+  const { data: user, isLoading } = useGetSelfDetailsQuery();
+  const reduxDispatch = useDispatch();
 
-  if (!isLoading && user) {
-    reduxDispatch(setIsLoggedIn({ isLoggedIn: true }));
-  }
+  useEffect(() => {
+    if (!isLoading && user) {
+      reduxDispatch(setIsLoggedIn({ isLoggedIn: true }));
+      reduxDispatch(
+        setUserData({
+          first_name: user?.first_name,
+          imageURL: user?.picture?.url,
+          roles: user?.roles,
+        })
+      );
+    }
+  }, [isLoading, user, reduxDispatch]);
 
   return props.children;
 }

--- a/src/store/global.ts
+++ b/src/store/global.ts
@@ -1,11 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { RolesType } from '../components/MembersSectionNew/types/MembersSection.type';
 
 interface globalState {
   isLoggedIn: boolean;
+  first_name: string | null;
+  imageURL: string | null;
+  roles: RolesType | null;
 }
 
 const initialState: globalState = {
   isLoggedIn: false,
+  first_name: null,
+  imageURL: null,
+  roles: null,
 };
 
 export const global = createSlice({
@@ -15,9 +22,14 @@ export const global = createSlice({
     setIsLoggedIn: (state, { payload: { isLoggedIn } }) => {
       state.isLoggedIn = isLoggedIn;
     },
+    setUserData: (state, { payload: { first_name, imageURL, roles } }) => {
+      state.first_name = first_name;
+      state.imageURL = imageURL;
+      state.roles = roles;
+    },
   },
 });
 
-export const { setIsLoggedIn } = global.actions;
+export const { setIsLoggedIn, setUserData } = global.actions;
 
 export default global.reducer;

--- a/src/utils/customHooks.tsx
+++ b/src/utils/customHooks.tsx
@@ -1,12 +1,9 @@
 import { useSelector } from "react-redux";
-import { useGetSelfDetailsQuery } from "../services/serverApi"
 import { RootState } from "../store";
 
 export const useGetIsSuperUser = (): boolean => {
-  const { isLoggedIn } = useSelector((state: RootState) => state.global);
-  const { data } = useGetSelfDetailsQuery(undefined, {
-    skip: !isLoggedIn
-  })
-  if (data?.roles?.super_user) return true;
+  const { roles } = useSelector((state: RootState) => state.global);
+
+  if (roles?.super_user) return true;
   return false;
-}
+};


### PR DESCRIPTION
## Issue Ticket Number
- Closes: https://github.com/Real-Dev-Squad/members-site/issues/104
Note: Don't close the issue once this PR get merge there are other PRs too


## Description
- Setup global state for user self data as we are calling `useGetSelfDetailsQuery` hooks multiple times, so to reduce call to the `/self` API i have setup a global state for that.
- When user logged in we are only setting the values which are required over the app and when user logged out setting the state to `null`

**Breaking Changes**

-   [ ] Yes
-   [x] No

**Development Tested?**

-   [x] Yes
-   [ ] No

### Screenshots


https://github.com/Real-Dev-Squad/members-site/assets/22213872/c10d54f0-87ff-4fb5-b4be-7b9ce621ad39



## Test Coverage

Test will be covered in upcoming PR.