### PR TITLE
fix: place footer to bottom when no full screen content present

### DIFF
--- a/src/components/Layout/LayoutComponent.tsx
+++ b/src/components/Layout/LayoutComponent.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import Dropdown from '../Dropdown/Dropdown';
 import { DROPDOWN_LINKS } from '../Dropdown/DropdownConstants';
 import Footer from '../Footer';
+import styles from '@/styles/Home.module.css';
 
 const MemberRoleUpdateModal = dynamic(
   () => import('@/src/components/Modals/MemberRoleUpdateModal'),
@@ -65,9 +66,9 @@ export default function LayoutComponent({ children }: Props) {
     );
 
   return (
-    <Box position="relative">
+    <Box className={styles.main} position="relative">
       <>{NavbarComponent}</>
-      <Box as="main">
+      <Box className={styles.content} as="main">
         <Box>{children}</Box>
       </Box>
       {isUserRoleUpdateModalVisible && <MemberRoleUpdateModal />}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -10,12 +10,13 @@
 
 .main {
   min-height: 100vh;
-  padding: 4rem 0;
-  flex: 1;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  flex-flow: column;
+  height: 100%;
+}
+
+.content {
+  flex: 1 1 auto;
 }
 
 .footer {


### PR DESCRIPTION
<!-- Date Here in dd mm yyyy-->
Date: 31-07-2024
<!--Developer Name Here-->
Developer Name: Surendar Singh

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#148 

## Description
<!--Description of the changes made in this PR-->
- Add CSS style for ".main" and ".content" div on the layout
- ".main" takes the full height of the screen
- ".content" takes up full empty screen space which automatically places the footer at the bottom

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/32b05892-6cc7-4cb3-b936-1104c037062d)
![image](https://github.com/user-attachments/assets/572b5619-6d2e-4d9c-a7d8-04c0cf2261bc)
![image](https://github.com/user-attachments/assets/c86505fd-65c5-4fcc-8526-7b38f4ac4528)
![image](https://github.com/user-attachments/assets/ef837b52-ed0c-4675-bfa0-db0afe397872)

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
This fail tests are not related to the UI changes that I made.

![image](https://github.com/user-attachments/assets/7d3389a5-b969-44c1-8155-0edd08785908)

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
