### PR TITLE
integreate api to get all members list and paginate non members data

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import MembersSectionMain from '@/src/components/MembersSectionNew/MembersSectio
 import NewMemberSection from '@/src/components/NewMemberSection';
 import { UserType } from '../src/components/MembersSectionNew/types/MembersSection.type';
 import { MaintenancePage } from '@/src/components/MaintenancePage/MaintenancePage';
+import { useRouter } from 'next/router';
 type PictureType = {
   publicId: string;
   url: string;
@@ -32,17 +33,26 @@ type PropsType = {
   pageProps: PagePropsType;
 };
 
-export default function Home(props: PropsType) {
+export default function Home() {
+  const { query } = useRouter()
+
+  if (query.dev === "true") {
+    return (
+      <div className={styles.container}>
+        <div>
+          <h1 className={styles.heading}>Real Dev Squad Members</h1>
+          <MembersSectionMain />
+        </div>
+        <div>
+          <h1 className={styles.heading}>{NEW_USER}</h1>
+          <NewMemberSection />
+        </div>
+      </div>
+    );
+  }
+
+  // TODO: Remove this once the /users api has support for `role` query param
   return (
-    <div className={styles.container}>
-      <div>
-        <h1 className={styles.heading}>Real Dev Squad Members</h1>
-        <MembersSectionMain />
-      </div>
-      <div>
-        <h1 className={styles.heading}>{NEW_USER}</h1>
-        <NewMemberSection />
-      </div>
-    </div>
-  );
+    <MaintenancePage />
+  )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,13 +33,6 @@ type PropsType = {
 };
 
 export default function Home(props: PropsType) {
-  // TODO: Remove this once the /users api has support for `role` query param
-  if (true) {
-    return (
-      <MaintenancePage />
-    )
-  }
-
   return (
     <div className={styles.container}>
       <div>

--- a/src/components/NewMemberSection/index.tsx
+++ b/src/components/NewMemberSection/index.tsx
@@ -1,14 +1,31 @@
-import { Avatar, Box } from '@chakra-ui/react';
+import { useGetUserWithLoadMore } from '@/src/services/serverApi';
 import NewMemberSectionPresentation from './Presentation';
-import { useGetUsers } from '@/src/services/serverApi';
+import { Button } from '@chakra-ui/react';
+import styles from './newMemberSection.module.css'
 
 export default function NewMemberSection() {
-  // we will make the api call here
-  const { data, isLoading, isFetching } = useGetUsers();
+  const { data, isLoading, isFetching, loadMore, links } = useGetUserWithLoadMore()
+
   return (
-    <NewMemberSectionPresentation
-      data={data}
-      isLoading={isLoading || isFetching}
-    />
+    <div>
+      <NewMemberSectionPresentation
+        data={data}
+        isLoading={isLoading}
+      />
+
+      {links?.next && links.next.length &&
+        <div className={styles.newMemberSectionLoadMore__container}>
+
+          <Button
+            onClick={loadMore}
+            isLoading={isFetching}
+            loadingText="Loading..."
+            className={styles.newMemberSectionLoadMore__button}
+          >
+            Load More
+          </Button>
+        </div>
+      }
+    </div>
   );
 }

--- a/src/components/NewMemberSection/newMemberSection.module.css
+++ b/src/components/NewMemberSection/newMemberSection.module.css
@@ -6,3 +6,38 @@
   gap: 10px;
   justify-content: center;
 }
+
+.newMemberSectionLoadMore__container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.newMemberSectionLoadMore__button {
+  height: 32px;
+  margin: 0 auto;
+  color: #fff;
+  font-size: 0.875rem;
+  border-radius: 100px;
+  padding: 0 0.75rem;
+  background-color: var(--primary-color);
+  transition: all 0.2s ease-in-out;
+}
+
+.newMemberSectionLoadMore__button:hover {
+  opacity: 0.8;
+}
+
+.newMemberSectionLoadMore__button:active {
+  scale: 0.95;
+}
+
+.newMemberSectionLoadMore__button:disabled {
+  color: #020617;
+  background-color: #e2e8f0;
+}
+
+.newMemberSectionLoadMore__button:disabled:hover {
+  color: #020617;
+  background-color: #e2e8f0;
+}

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -1,15 +1,16 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { HYDRATE } from 'next-redux-wrapper';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { UserType } from '../components/MembersSectionNew/types/MembersSection.type';
 import {
-  tags,
   levels,
-  tagsWithLevelType,
   skills,
+  tags,
+  tagsWithLevelType,
   updateSkills,
 } from '../components/Modals/MembersSkillUpdateModal/types/memberSkills';
-import { UserType } from '../components/MembersSectionNew/types/MembersSection.type';
 import { UsersResponseType } from '../types/user';
-import { useDispatch } from 'react-redux';
 import { notifyError, notifySuccess } from '../utils/toast';
 const BASE_URL = 'https://api.realdevsquad.com';
 
@@ -52,6 +53,18 @@ export const serverApi = createApi({
     getUserActiveTask: builder.query<Object, string>({
       query: (userName) => `${BASE_URL}/tasks/${userName}?status=IN_PROGRESS`,
       providesTags: ['ActiveTasks'],
+    }),
+    getUsersWithLoadMore: builder.query<UsersResponseType, string | void>({
+      query: (nextUrl) => (nextUrl ? nextUrl : `${BASE_URL}/users?size=100`),
+      serializeQueryArgs: ({ endpointName }) => endpointName,
+      merge: (currentCache, newItems) => {
+        currentCache.users.push(...newItems.users);
+        currentCache.links = newItems.links;
+      },
+      forceRefetch({ currentArg, previousArg }) {
+        return currentArg !== previousArg;
+      },
+      providesTags: ['AllUsers'],
     }),
     // Mutations
     // TODO add types for mutations
@@ -140,6 +153,41 @@ export const useGetUsers = () => {
     isLoading,
     isFetching,
     error,
+  };
+};
+
+export const useGetUserWithLoadMore = () => {
+  const [nextUrl, setNextUrl] = useState<string | void>(undefined);
+  const { data, isLoading, isFetching, error } =
+    serverApi.useGetUsersWithLoadMoreQuery(nextUrl);
+
+  const usersWithoutMemberRole = data?.users?.filter(
+    (user: UserType) =>
+      !user?.roles.member &&
+      user?.first_name &&
+      !user.roles.archived &&
+      user.roles.in_discord,
+  );
+
+  const sortedNonMembers = usersWithoutMemberRole?.sort((a, b) =>
+    a.first_name.toLowerCase() > b.first_name.toLowerCase() ? 1 : -1,
+  );
+
+  const nextUrlLink = data?.links?.next;
+
+  const loadMore = () => {
+    if (nextUrlLink && !!nextUrlLink.length) {
+      setNextUrl(data.links.next);
+    }
+  };
+
+  return {
+    data: sortedNonMembers,
+    isLoading,
+    isFetching,
+    error,
+    loadMore,
+    links: data?.links,
   };
 };
 

--- a/src/services/serverApi.ts
+++ b/src/services/serverApi.ts
@@ -20,12 +20,23 @@ export const serverApi = createApi({
       return action.payload[reducerPath];
     }
   },
-  tagTypes: ['Skill', 'Contributions', 'ActiveTasks', 'AllUsers', 'User'],
+  tagTypes: [
+    'Skill',
+    'Contributions',
+    'ActiveTasks',
+    'AllUsers',
+    'User',
+    'AllMembers',
+  ],
   endpoints: (builder) => ({
     // Queries
     getAllUsers: builder.query<UsersResponseType, void>({
       query: () => BASE_URL + '/users?size=100',
       providesTags: ['AllUsers'],
+    }),
+    getAllMembers: builder.query<UsersResponseType, void>({
+      query: () => BASE_URL + '/users?roles=member',
+      providesTags: ['AllMembers'],
     }),
     getUser: builder.query<UserType, string>({
       query: (userName) => `${BASE_URL}/users/${userName}`,
@@ -87,17 +98,15 @@ export const {
   useUpdateMemberRoleMutation,
   useUpdateTaskStatusMutation,
   useUpdateUserRoleMutation,
+  useGetAllMembersQuery,
 } = serverApi;
 
 export const useGetMembers = () => {
   const { data, isLoading, isFetching, error } =
-    serverApi.useGetAllUsersQuery();
+    serverApi.useGetAllMembersQuery();
 
   const usersWithMemberRole = data?.users?.filter(
-    (member: UserType) =>
-      member?.roles.member === true &&
-      member?.first_name &&
-      !member.roles.archived,
+    (member: UserType) => member?.first_name && !member.roles.archived,
   );
   // To show the members in an Alphabetical Order w.r.t their first name.
   const sortedMembers = usersWithMemberRole?.sort((a, b) =>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -13,4 +13,8 @@ type RolesType = {
 export type UsersResponseType = {
   message: string;
   users: UserType[];
+  links: {
+    prev: string;
+    next: string;
+  };
 };


### PR DESCRIPTION
### Date: 18th Aug 2024 
### Developer Name: Yash Raj

## Issue Ticket Number
- #152 

## Description
- create a new hook to allow us to load non-member's data conditionally.
- add a `Load More` button on the homepage to load non-member data.
- integrate `users?roles=member` API to load only members data.

### Documentation Updated?
- [ ] Yes
- [x] No

### Under Feature Flag
- [x] Yes
- [ ] No

### Database Changes
- [ ] Yes
- [x] No

### Breaking Changes
- [ ] Yes
- [ ] No

### Development Tested?
- [x] Yes
- [ ] No

## Screenshots
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/02b4efe1-eb52-46fc-b759-84c0de669a26">